### PR TITLE
remove multiple sync_gateway launches

### DIFF
--- a/tests/cbl-large-revisions-compact.js
+++ b/tests/cbl-large-revisions-compact.js
@@ -42,15 +42,6 @@ test("cleanup cb bucket", test_conf, function (t) {
     }
 })
 
-// start sync gateway
-test("start syncgateway", function (t) {
-    common.launchSG(t, function (_sg) {
-        sg = _sg
-        gateway = sg.url
-        t.end()
-    })
-})
-
 // start client endpoint
 test("start test client", function (t) {
     common.launchClient(t, function (_server) {

--- a/upgrade_test/fabfile.py
+++ b/upgrade_test/fabfile.py
@@ -109,10 +109,16 @@ def compose_cbl_url(product,version,platform):
 		build_url = build_url + url_append(['release','1.1.0' , platform , version ])
 		build_name = c[platform+'Build'] + version + ".zip"
 		build_url = build_url + build_name
+
+	elif version and '1.1.1' in version:
+		build_url = build_url + url_append(['release', '1.1.1', platform, version ])
+		build_name = c[platform+'Build'] + version + '.zip'
+		build_url = build_url + build_name
 	
 	else:
 		print "Error: Should not have landed here. No CBL version found"
-	
+
+	print "compose_cbl_url: build_url: {0}, build_name: {1}".format(build_url, build_name)
 	return build_url,build_name
 
 


### PR DESCRIPTION
1.) This fixes our hanging functional tests. Did you mean to launch multiple instances of sg for this test?
2.) Added 1.1.1 target to fab file so we can target CBLite 1.1.1 in sync_gateway functional tests
